### PR TITLE
Updated workflows & dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,9 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
-    reviewers:
-      - "Fank"
+      interval: "weekly"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-    reviewers:
-      - "Fank"
+      interval: "weekly"

--- a/.github/templates/go-licenses.md.tpl
+++ b/.github/templates/go-licenses.md.tpl
@@ -1,0 +1,5 @@
+## [go-licenses](https://github.com/google/go-licenses) report
+
+{{- range . }}
+- {{ .Name }} ({{ .Version }}) [{{ .LicenseName }}]({{ .LicenseURL }})
+{{- end }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - master
   pull_request:
 
 permissions:
@@ -13,7 +12,7 @@ permissions:
 
 jobs:
   golangci:
-    name: lint
+    name: Go Lint
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -34,11 +33,10 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
-        with:
-          version: latest
 
   test:
     runs-on: ubuntu-latest
+    name: Go Test
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -63,31 +61,3 @@ jobs:
         uses: robherley/go-test-action@v0
         with:
           testArguments: ./...
-
-  license-check:
-    runs-on: ubuntu-latest
-    name: License Check
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: ./go.mod
-
-      - name: Install go-licenses
-        run: go install github.com/google/go-licenses@latest
-        shell: bash
-
-      - name: Check licenses
-        run: >
-          go-licenses check ./...
-          --ignore ${{ github.repository }}
-        shell: bash
-
-      - name: Get licenses list
-        run: >
-          go-licenses csv ./...
-          --ignore ${{ github.repository }}
-        shell: bash

--- a/.github/workflows/license_go.yml
+++ b/.github/workflows/license_go.yml
@@ -1,0 +1,48 @@
+name: License Go
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  license-check:
+    runs-on: ubuntu-latest
+    name: License Check
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
+
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses@latest
+
+      - name: Check licenses
+        run: go-licenses check ./...
+
+  license-report:
+    runs-on: ubuntu-latest
+    name: License Report
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
+
+      - name: Install go-licenses
+        run: go install github.com/google/go-licenses@latest
+
+      - name: Report to GitHub Step Summary
+        run: >
+          go-licenses report ./...
+          --template .github/templates/go-licenses.md.tpl
+          >> $GITHUB_STEP_SUMMARY
+        shell: bash


### PR DESCRIPTION
This pull request includes several changes to the GitHub Actions workflows and configuration files, primarily focusing on updating schedules, renaming jobs, and reorganizing license checks and reports. The most important changes include modifying the Dependabot schedule, adding a new license report template, and restructuring the Go workflow.

### Workflow and Configuration Updates:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L6-R11): Changed the update interval for `gomod` and `github-actions` from daily to weekly.

### License Management:

* [`.github/templates/go-licenses.md.tpl`](diffhunk://#diff-ff560d5d3ad99824bd9294a7b7b013edd79c731be891ef1ab2b9b6b9949bbc49R1-R5): Added a new template for the `go-licenses` report.

### Workflow Restructuring:

* `.github/workflows/go.yml`:
  * Removed the `license-check` job and renamed the lint and test jobs for clarity. [[1]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL16-R15) [[2]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL37-R39) [[3]](diffhunk://#diff-678682767f2477de3e3c546746f8568b9a1942b2c647d32331d7e774b8ff8d9fL66-L93)
  * Updated the branches monitored for pushes to exclude `master`.

* [`.github/workflows/license_go.yml`](diffhunk://#diff-4086cd651c06d7a18d9940946971a0bff2d4c636298ab9688c723a93cb11417aR1-R48): Added a new workflow file dedicated to license checking and reporting, including steps for checking licenses and generating a report.