### PR TITLE
Create release with changelog on tag creation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*' # Trigger on version tags like v1.0.0, v2.1.0, etc.
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Git
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "github-actions@github.com"
+
+      - name: Generate Changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v5
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: Release ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.changelog }}  # Attach changelog


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow to automate the creation of GitHub releases and changelogs whenever a new version tag is pushed. The key changes include configuring the workflow to trigger on version tags, setting up Git, generating a changelog, and creating the release.

Automation of GitHub releases and changelogs:

* [`.github/workflows/changelog.yml`](diffhunk://#diff-a0aba5a2bd30b2f80a3a18aa24ce43670b1320ca0a8b9c103bb3bc971ae30a85R1-R33): Added a new GitHub Actions workflow named "Release" that triggers on version tags, sets up Git, generates a changelog using `mikepenz/release-changelog-builder-action`, and creates a GitHub release with the generated changelog attached.