### PR TITLE
Updated the Go version from 1.22 to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/enthus-golang/itscope
 
-go 1.22
+go 1.24
 
 require (
 	github.com/sirupsen/logrus v1.9.3


### PR DESCRIPTION
This pull request updates the Go module version in the `go.mod` file to align with the latest Go language features and improvements.

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3): Updated the Go version from `1.22` to `1.24` to ensure compatibility with the latest language features and performance enhancements.