### PR TITLE
ci: add explicit read-only permissions to license workflow

### DIFF
--- a/.github/workflows/license_go.yml
+++ b/.github/workflows/license_go.yml
@@ -7,6 +7,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   license-check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds workflow-level `permissions: contents: read` block to `.github/workflows/license_go.yml` to resolve CodeQL `actions/missing-workflow-permissions` alerts. The workflow only reads code and runs `go-licenses` — no write scope is needed.