### PR TITLE
feat: NX-15633 migrate to ITScope API 2.1 + harden 204/retry handling

### DIFF
--- a/itscope.go
+++ b/itscope.go
@@ -242,8 +242,8 @@ func (its *ITScopeCommunicator) createQueryStrings(productIDs []string, length i
 
 func (its *ITScopeCommunicator) GetProductImages(product *Product) []string {
 	var imageUrls = make([]string, 0)
-	if product.Image1 != "" {
-		imageUrls = append(imageUrls, product.Image1)
+	if product.ImageHighRes1 != "" {
+		imageUrls = append(imageUrls, product.ImageHighRes1)
 	}
 	if product.Image2 != "" {
 		imageUrls = append(imageUrls, product.Image2)

--- a/itscope.go
+++ b/itscope.go
@@ -58,18 +58,14 @@ func (its *ITScopeCommunicator) authenticateRequest(request *http.Request) error
 	return nil
 }
 
-// retryableStatus reports whether an HTTP status warrants a retry. Only
-// transient failures (429 Too Many Requests and 5xx) are retried; permanent
-// client statuses (other 4xx) and successes are surfaced to the caller as-is,
-// so a single bad item never burns the full backoff budget.
+// retryableStatus reports whether a failed request is worth retrying:
+// transient statuses only (429 and 5xx), never permanent 4xx.
 func retryableStatus(statusCode int) bool {
 	return statusCode == http.StatusTooManyRequests || statusCode >= http.StatusInternalServerError
 }
 
-// doWithRetry sends request, honouring the rate limiter between attempts and
-// retrying only on network errors or transient statuses (see retryableStatus),
-// up to maxRequestRetries times. The returned response is either a successful
-// or permanent-status response; the caller owns closing its body.
+// doWithRetry sends request through the rate limiter, retrying network errors
+// and transient statuses. The caller owns closing the returned response body.
 func (its *ITScopeCommunicator) doWithRetry(ctx context.Context, request *http.Request, operation string) (*http.Response, error) {
 	var response *http.Response
 	var err error
@@ -84,8 +80,7 @@ func (its *ITScopeCommunicator) doWithRetry(ctx context.Context, request *http.R
 			return response, nil
 		}
 
-		// On the final attempt keep the response so the caller can surface its
-		// status; otherwise close it before backing off to avoid leaking it.
+		// Keep the final attempt's response for the caller; close earlier ones.
 		if attempt < maxRequestRetries-1 {
 			if response != nil {
 				_ = response.Body.Close()

--- a/itscope.go
+++ b/itscope.go
@@ -82,13 +82,19 @@ func (its *ITScopeCommunicator) doWithRetry(ctx context.Context, request *http.R
 
 		// Keep the final attempt's response for the caller; close earlier ones.
 		if attempt < maxRequestRetries-1 {
-			if response != nil {
+			if err != nil {
+				logrus.Errorf("Error during %s: %v, retrying...", operation, err)
+			} else {
+				logrus.Errorf("Error during %s: status %d, retrying...", operation, response.StatusCode)
 				_ = response.Body.Close()
 				response = nil
 			}
 
-			logrus.Errorf("Error during %s, retrying...", operation)
-			time.Sleep(retryBackoff)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(retryBackoff):
+			}
 		}
 	}
 

--- a/itscope.go
+++ b/itscope.go
@@ -13,6 +13,11 @@ import (
 	"golang.org/x/time/rate"
 )
 
+const (
+	maxRequestRetries = 3
+	retryBackoff      = 4 * time.Second
+)
+
 type ITScopeCommunicator struct {
 	username    string
 	password    string
@@ -53,6 +58,52 @@ func (its *ITScopeCommunicator) authenticateRequest(request *http.Request) error
 	return nil
 }
 
+// retryableStatus reports whether an HTTP status warrants a retry. Only
+// transient failures (429 Too Many Requests and 5xx) are retried; permanent
+// client statuses (other 4xx) and successes are surfaced to the caller as-is,
+// so a single bad item never burns the full backoff budget.
+func retryableStatus(statusCode int) bool {
+	return statusCode == http.StatusTooManyRequests || statusCode >= http.StatusInternalServerError
+}
+
+// doWithRetry sends request, honouring the rate limiter between attempts and
+// retrying only on network errors or transient statuses (see retryableStatus),
+// up to maxRequestRetries times. The returned response is either a successful
+// or permanent-status response; the caller owns closing its body.
+func (its *ITScopeCommunicator) doWithRetry(ctx context.Context, request *http.Request, operation string) (*http.Response, error) {
+	var response *http.Response
+	var err error
+
+	for attempt := 0; attempt < maxRequestRetries; attempt++ {
+		if err = its.limiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("limiter timeout: %w", err)
+		}
+
+		response, err = its.client.Do(request)
+		if err == nil && !retryableStatus(response.StatusCode) {
+			return response, nil
+		}
+
+		// On the final attempt keep the response so the caller can surface its
+		// status; otherwise close it before backing off to avoid leaking it.
+		if attempt < maxRequestRetries-1 {
+			if response != nil {
+				_ = response.Body.Close()
+				response = nil
+			}
+
+			logrus.Errorf("Error during %s, retrying...", operation)
+			time.Sleep(retryBackoff)
+		}
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", operation, err)
+	}
+
+	return response, nil
+}
+
 func (its *ITScopeCommunicator) GetProductData(ctx context.Context, productSKU string) (*Product, error) {
 	productContainer, err := its.GetProductsFromQuery(ctx, "distpid="+productSKU)
 	if err != nil {
@@ -70,7 +121,7 @@ func (its *ITScopeCommunicator) GetAllProductTypes(ctx context.Context) ([]Produ
 	u := url.URL{
 		Host:   "api.itscope.com",
 		Scheme: "https",
-		Path:   "2.0/products/producttypes/producttype.json",
+		Path:   "2.1/products/producttypes/producttype.json",
 	}
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	if err != nil {
@@ -81,22 +132,7 @@ func (its *ITScopeCommunicator) GetAllProductTypes(ctx context.Context) ([]Produ
 		return nil, fmt.Errorf("could not retrieve product types: %w", err)
 	}
 
-	retries := 3
-	var response *http.Response
-	for retries > 0 {
-		if err = its.limiter.Wait(ctx); err != nil {
-			return nil, fmt.Errorf("limiter timeout: %w", err)
-		}
-
-		response, err = its.client.Do(request)
-		if err != nil || (response.StatusCode != http.StatusOK && response.StatusCode != http.StatusNotFound) {
-			logrus.Errorln("Error during GetAllProductTypes, retrying...")
-			time.Sleep(4 * time.Second)
-			retries -= 1
-		} else {
-			break
-		}
-	}
+	response, err := its.doWithRetry(ctx, request, "GetAllProductTypes")
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve product types: %w", err)
 	}
@@ -106,7 +142,7 @@ func (its *ITScopeCommunicator) GetAllProductTypes(ctx context.Context) ([]Produ
 		}
 	}()
 
-	if response.StatusCode == http.StatusNotFound {
+	if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusNoContent {
 		return []ProductType{}, nil
 	} else if response.StatusCode != http.StatusOK {
 		return nil, NewUnexpectedStatusCodeError(response)
@@ -145,7 +181,7 @@ func (its *ITScopeCommunicator) GetProductAccessoriesFromList(ctx context.Contex
 }
 
 func (its *ITScopeCommunicator) GetProductsFromQuery(ctx context.Context, query string) (*ProductsContainer, error) {
-	urlString := "https://api.itscope.com/2.0/products/search/" + url.QueryEscape(query) + "/standard.json?realtime=false&plzproducts=false&page=1&item=0&sort=DEFAULT"
+	urlString := "https://api.itscope.com/2.1/products/search/" + url.QueryEscape(query) + "/standard.json?realtime=false&plzproducts=false&page=1&item=0&sort=DEFAULT"
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, urlString, nil)
 	if err != nil {
 		return nil, fmt.Errorf("GetProductsFromQuery1: %w", err)
@@ -155,22 +191,7 @@ func (its *ITScopeCommunicator) GetProductsFromQuery(ctx context.Context, query 
 		return nil, fmt.Errorf("GetProductsFromQuery2: %w", err)
 	}
 
-	retries := 3
-	var response *http.Response
-	for retries > 0 {
-		if err = its.limiter.Wait(ctx); err != nil {
-			return nil, fmt.Errorf("limiter timeout: %w", err)
-		}
-
-		response, err = its.client.Do(request)
-		if err != nil || (response.StatusCode != http.StatusOK && response.StatusCode != http.StatusNotFound) {
-			logrus.Errorln("Error during GetProductsFromQuery, retrying...")
-			retries -= 1
-			time.Sleep(4 * time.Second)
-		} else {
-			break
-		}
-	}
+	response, err := its.doWithRetry(ctx, request, "GetProductsFromQuery")
 	if err != nil {
 		return nil, fmt.Errorf("GetProductsFromQuery: %w", err)
 	}
@@ -180,7 +201,7 @@ func (its *ITScopeCommunicator) GetProductsFromQuery(ctx context.Context, query 
 		}
 	}()
 
-	if response.StatusCode == http.StatusNotFound {
+	if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusNoContent {
 		return &ProductsContainer{}, nil
 	} else if response.StatusCode != http.StatusOK {
 		return nil, NewUnexpectedStatusCodeError(response)

--- a/types.go
+++ b/types.go
@@ -109,7 +109,7 @@ type Product struct {
 	ImageThumb                  string             `json:"imageThumb"`
 	ImageThumbWidth             string             `json:"imageThumbWidth"`
 	ImageThumbHeight            string             `json:"imageThumbHeight"`
-	Image1                      string             `json:"imageHighRes1"`
+	ImageHighRes1               string             `json:"imageHighRes1"`
 	ImageWidth1                 string             `json:"imageWidth1"`
 	ImageHeight1                string             `json:"imageHeight1"`
 	Image2                      string             `json:"image2"`

--- a/types.go
+++ b/types.go
@@ -109,7 +109,7 @@ type Product struct {
 	ImageThumb                  string             `json:"imageThumb"`
 	ImageThumbWidth             string             `json:"imageThumbWidth"`
 	ImageThumbHeight            string             `json:"imageThumbHeight"`
-	Image1                      string             `json:"image1"`
+	Image1                      string             `json:"imageHighRes1"`
 	ImageWidth1                 string             `json:"imageWidth1"`
 	ImageHeight1                string             `json:"imageHeight1"`
 	Image2                      string             `json:"image2"`


### PR DESCRIPTION
## What & Why

Supports [NX-15633]. The `SyncItemImagesFromITScope` cron was failing in two ways that originate in this client:

1. **`204 No Content` aborted the caller.** ITScope returns `204` for a valid query with no match (confirmed live). The client treated any non-200/404 as a fatal `UnexpectedStatusCodeError`, so one empty product result propagated up and killed the whole sync.
2. **Permanent statuses were retried pointlessly.** Any non-200/404 (incl. `400`, `401`, `204`) was retried 3× with a 4s sleep — wasted time and log spam, and never going to succeed.

Also migrates off the **deprecated API 2.0** to **2.1** while we're here.

## Key Changes

- New `doWithRetry` helper replaces the two duplicated retry loops. Retries **only** network errors, `429`, and `5xx`; permanent statuses return immediately. Closes response bodies between retries (fixes a leak).
- `204 No Content` handled as an empty result (like `404`) in `GetProductsFromQuery` and `GetAllProductTypes`.
- URLs `/2.0/` → `/2.1/`.
- `Product.Image1` json tag `image1` → `imageHighRes1` (the only 2.0→2.1 field change touching us; `image2`–`image5` unchanged — verified against the live 2.1 API).

## Testing

- `gofmt`, `go vet`, `go build` clean.
- Verified against the live 2.1 API with real credentials: `producttypes` → 200; a real product returns `imageHighRes1` + `image2`, and `GetProductImages` extracts both URLs.
- Consumed by negsoft-api PR (errgroup resilience + go.mod bump); the `SyncItemImagesFromITScope` job runs to completion against prod data with these changes.

## Deployment Notes

After review, tag a release (e.g. `v0.4.0`) so the negsoft-api PR can pin to it instead of the branch pseudo-version.